### PR TITLE
BUGFIX: make dataclean should save data in subdir of trash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,8 @@ clean: dataclean
 dataclean:
 	mkdir -p data trash
 	touch "data/`date`"
-	mv data/* trash/.
+	cp -r data trash/
+	rm data/*
 
 DEATH=rm -rf trash data savedata par-run-dir.*
 distclean: clean


### PR DESCRIPTION
make dataclean was dumping lots of different simulations into one directory with conflicting names. now just dumps entire data directory into ``trash''.